### PR TITLE
feat: use in-house hubstaff client

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,15 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@app-masters/hubstaff-node-client": "^2.0.4",
     "@heroicons/react": "^2.0.18",
     "@prisma/client": "^4.16.2",
     "@tanstack/react-table": "^8.9.3",
+    "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "next": "13.4.6",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@types/eslint": "^8.40.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  '@app-masters/hubstaff-node-client':
-    specifier: ^2.0.4
-    version: 2.0.4
   '@heroicons/react':
     specifier: ^2.0.18
     version: 2.0.18(react@18.2.0)
@@ -17,6 +14,9 @@ dependencies:
   '@tanstack/react-table':
     specifier: ^8.9.3
     version: 8.9.3(react-dom@18.2.0)(react@18.2.0)
+  jwt-decode:
+    specifier: ^3.1.2
+    version: 3.1.2
   lodash:
     specifier: ^4.17.21
     version: 4.17.21
@@ -29,6 +29,9 @@ dependencies:
   react-dom:
     specifier: 18.2.0
     version: 18.2.0(react@18.2.0)
+  zod:
+    specifier: ^3.21.4
+    version: 3.21.4
 
 devDependencies:
   '@types/eslint':
@@ -97,16 +100,6 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
     dev: true
-
-  /@app-masters/hubstaff-node-client@2.0.4:
-    resolution: {integrity: sha512-BdN6KmA6E/moba8lvO1wo4K/xi2vTRE8var3iyXDG03k6GxssOU8bNbhW5Lh7lzVkeVeI6OnwhpUYVlPNWRQug==}
-    dependencies:
-      axios: 0.21.4
-      jwt-decode: 3.1.2
-      request: 2.88.2
-    transitivePeerDependencies:
-      - debug
-    dev: false
 
   /@babel/runtime@7.22.5:
     resolution: {integrity: sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==}
@@ -595,6 +588,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+    dev: true
 
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -687,24 +681,9 @@ packages:
       get-intrinsic: 1.2.1
     dev: true
 
-  /asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-    dependencies:
-      safer-buffer: 2.1.2
-    dev: false
-
-  /assert-plus@1.0.0:
-    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
-    engines: {node: '>=0.8'}
-    dev: false
-
   /ast-types-flow@0.0.7:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
     dev: true
-
-  /asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: false
 
   /autoprefixer@10.4.14(postcss@8.4.24):
     resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
@@ -727,26 +706,10 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
-  /aws-sign2@0.7.0:
-    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
-    dev: false
-
-  /aws4@1.12.0:
-    resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
-    dev: false
-
   /axe-core@4.7.2:
     resolution: {integrity: sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==}
     engines: {node: '>=4'}
     dev: true
-
-  /axios@0.21.4:
-    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
-    dependencies:
-      follow-redirects: 1.15.2
-    transitivePeerDependencies:
-      - debug
-    dev: false
 
   /axobject-query@3.2.1:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
@@ -757,12 +720,6 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
-
-  /bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
-    dependencies:
-      tweetnacl: 0.14.5
-    dev: false
 
   /big-integer@1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
@@ -840,10 +797,6 @@ packages:
   /caniuse-lite@1.0.30001511:
     resolution: {integrity: sha512-NaWPJawcoedlghN4P7bDNeADD7K+rZaY6V8ZcME7PkEZo/nfOg+lnrUgRWiKbNxcQ4/toFKSxnS4WdbyPZnKkw==}
 
-  /caseless@0.12.0:
-    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
-    dev: false
-
   /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -882,13 +835,6 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
-  /combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-    dependencies:
-      delayed-stream: 1.0.0
-    dev: false
-
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -897,10 +843,6 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
-
-  /core-util-is@1.0.2:
-    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
-    dev: false
 
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -924,13 +866,6 @@ packages:
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
-
-  /dashdash@1.14.1:
-    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
-    engines: {node: '>=0.10'}
-    dependencies:
-      assert-plus: 1.0.0
-    dev: false
 
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -990,11 +925,6 @@ packages:
       object-keys: 1.1.1
     dev: true
 
-  /delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-    dev: false
-
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1028,13 +958,6 @@ packages:
     dependencies:
       esutils: 2.0.3
     dev: true
-
-  /ecc-jsbn@0.1.2:
-    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
-    dependencies:
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-    dev: false
 
   /electron-to-chromium@1.4.447:
     resolution: {integrity: sha512-sxX0LXh+uL41hSJsujAN86PjhrV/6c79XmpY0TvjZStV6VxIgarf8SRkUoUTuYmFcZQTemsoqo8qXOGw5npWfw==}
@@ -1452,17 +1375,9 @@ packages:
       strip-final-newline: 3.0.0
     dev: true
 
-  /extend@3.0.2:
-    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
-    dev: false
-
-  /extsprintf@1.3.0:
-    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
-    engines: {'0': node >=0.6.0}
-    dev: false
-
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
 
   /fast-glob@3.3.0:
     resolution: {integrity: sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==}
@@ -1477,6 +1392,7 @@ packages:
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    dev: true
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
@@ -1522,34 +1438,11 @@ packages:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
 
-  /follow-redirects@1.15.2:
-    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
-
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
       is-callable: 1.2.7
     dev: true
-
-  /forever-agent@0.6.1:
-    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
-    dev: false
-
-  /form-data@2.3.3:
-    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
-    engines: {node: '>= 0.12'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-    dev: false
 
   /fraction.js@4.2.0:
     resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
@@ -1612,12 +1505,6 @@ packages:
     dependencies:
       resolve-pkg-maps: 1.0.0
     dev: true
-
-  /getpass@0.1.7:
-    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
-    dependencies:
-      assert-plus: 1.0.0
-    dev: false
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1724,20 +1611,6 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
-  /har-schema@2.0.0:
-    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
-    engines: {node: '>=4'}
-    dev: false
-
-  /har-validator@5.1.5:
-    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
-    engines: {node: '>=6'}
-    deprecated: this library is no longer supported
-    dependencies:
-      ajv: 6.12.6
-      har-schema: 2.0.0
-    dev: false
-
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
     dev: true
@@ -1776,15 +1649,6 @@ packages:
     dependencies:
       function-bind: 1.1.1
     dev: true
-
-  /http-signature@1.2.0:
-    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
-    engines: {node: '>=0.8', npm: '>=1.3.7'}
-    dependencies:
-      assert-plus: 1.0.0
-      jsprim: 1.4.2
-      sshpk: 1.17.0
-    dev: false
 
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -1984,10 +1848,6 @@ packages:
       has-tostringtag: 1.0.0
     dev: true
 
-  /is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
-    dev: false
-
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
@@ -2005,10 +1865,6 @@ packages:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
-  /isstream@0.1.2:
-    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
-    dev: false
-
   /jiti@1.18.2:
     resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
     hasBin: true
@@ -2024,24 +1880,13 @@ packages:
       argparse: 2.0.1
     dev: true
 
-  /jsbn@0.1.1:
-    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
-    dev: false
-
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
-  /json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-    dev: false
+    dev: true
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
-
-  /json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-    dev: false
 
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -2049,16 +1894,6 @@ packages:
     dependencies:
       minimist: 1.2.8
     dev: true
-
-  /jsprim@1.4.2:
-    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
-    engines: {node: '>=0.6.0'}
-    dependencies:
-      assert-plus: 1.0.0
-      extsprintf: 1.3.0
-      json-schema: 0.4.0
-      verror: 1.10.0
-    dev: false
 
   /jsx-ast-utils@3.3.4:
     resolution: {integrity: sha512-fX2TVdCViod6HwKEtSWGHs57oFhVfCMwieb9PuRDgjDPh5XeqJiHFFFJCHxU5cnTc3Bu/GRL+kPiFmw8XWOfKw==}
@@ -2145,18 +1980,6 @@ packages:
       braces: 3.0.2
       picomatch: 2.3.1
     dev: true
-
-  /mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-    dev: false
-
-  /mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-    dependencies:
-      mime-db: 1.52.0
-    dev: false
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -2277,10 +2100,6 @@ packages:
     dependencies:
       path-key: 4.0.0
     dev: true
-
-  /oauth-sign@0.9.0:
-    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
-    dev: false
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2436,10 +2255,6 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
     dev: true
-
-  /performance-now@2.1.0:
-    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
-    dev: false
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -2620,18 +2435,10 @@ packages:
       react-is: 16.13.1
     dev: true
 
-  /psl@1.9.0:
-    resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
-    dev: false
-
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
-
-  /qs@6.5.3:
-    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
-    engines: {node: '>=0.6'}
-    dev: false
+    dev: true
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2683,33 +2490,6 @@ packages:
       define-properties: 1.2.0
       functions-have-names: 1.2.3
     dev: true
-
-  /request@2.88.2:
-    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
-    engines: {node: '>= 6'}
-    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.12.0
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 2.3.3
-      har-validator: 5.1.5
-      http-signature: 1.2.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      oauth-sign: 0.9.0
-      performance-now: 2.1.0
-      qs: 6.5.3
-      safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
-      tunnel-agent: 0.6.0
-      uuid: 3.4.0
-    dev: false
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2763,10 +2543,6 @@ packages:
       queue-microtask: 1.2.3
     dev: true
 
-  /safe-buffer@5.2.1:
-    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: false
-
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
@@ -2774,10 +2550,6 @@ packages:
       get-intrinsic: 1.2.1
       is-regex: 1.1.4
     dev: true
-
-  /safer-buffer@2.1.2:
-    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: false
 
   /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
@@ -2835,22 +2607,6 @@ packages:
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
-
-  /sshpk@1.17.0:
-    resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    dependencies:
-      asn1: 0.2.6
-      assert-plus: 1.0.0
-      bcrypt-pbkdf: 1.0.2
-      dashdash: 1.14.1
-      ecc-jsbn: 0.1.2
-      getpass: 0.1.7
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-      tweetnacl: 0.14.5
-    dev: false
 
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -3039,14 +2795,6 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /tough-cookie@2.5.0:
-    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
-    engines: {node: '>=0.8'}
-    dependencies:
-      psl: 1.9.0
-      punycode: 2.3.0
-    dev: false
-
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
@@ -3076,16 +2824,6 @@ packages:
       tslib: 1.14.1
       typescript: 5.1.3
     dev: true
-
-  /tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
-
-  /tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
-    dev: false
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -3142,25 +2880,11 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
+    dev: true
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
-
-  /uuid@3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-    dev: false
-
-  /verror@1.10.0:
-    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
-    engines: {'0': node >=0.6.0}
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.3.0
-    dev: false
 
   /watchpack@2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,8 @@ model HubstaffAccess {
   accessToken  String @db.VarChar(600)
   refreshToken String @db.VarChar(600)
 
+  exp Int @default(0) // Default to make sure its invalid if not provided
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }

--- a/src/app/components/ActivitiesList.tsx
+++ b/src/app/components/ActivitiesList.tsx
@@ -1,14 +1,13 @@
 'use client';
-import { type Activity } from '@app-masters/hubstaff-node-client/dist/types';
 import { createColumnHelper } from '@tanstack/react-table';
 import Table from './ui/table';
 
 interface Props {
-  activities: Activity[];
+  activities: any[];
 }
 
 const ActivitiesList = ({ activities }: Props) => {
-  const columnHelper = createColumnHelper<Activity>();
+  const columnHelper = createColumnHelper<any>();
 
   const columns = [
     columnHelper.accessor('id', {

--- a/src/app/components/ActivitiesList.tsx
+++ b/src/app/components/ActivitiesList.tsx
@@ -1,13 +1,14 @@
 'use client';
 import { createColumnHelper } from '@tanstack/react-table';
 import Table from './ui/table';
+import { type HubstaffActivity } from '../hubstaffValidators';
 
 interface Props {
-  activities: any[];
+  activities: HubstaffActivity[];
 }
 
 const ActivitiesList = ({ activities }: Props) => {
-  const columnHelper = createColumnHelper<any>();
+  const columnHelper = createColumnHelper<HubstaffActivity>();
 
   const columns = [
     columnHelper.accessor('id', {

--- a/src/app/components/ActivitiesSum.tsx
+++ b/src/app/components/ActivitiesSum.tsx
@@ -1,12 +1,11 @@
-import { type Activity } from '@app-masters/hubstaff-node-client/dist/types';
-
+/* eslint-disable */
 interface Props {
-  activities: Activity[];
+  activities: any[];
 }
 
 const ActivitiesSum = ({ activities }: Props) => {
   const trackedTime = activities.reduce(
-    (sum: number, activity: Activity) =>
+    (sum: number, activity: any) =>
       activity.tracked ? sum + activity.tracked : sum,
     0
   );

--- a/src/app/components/ActivitiesSum.tsx
+++ b/src/app/components/ActivitiesSum.tsx
@@ -1,12 +1,12 @@
-/* eslint-disable */
+import { type HubstaffActivity } from '../hubstaffValidators';
+
 interface Props {
-  activities: any[];
+  activities: HubstaffActivity[];
 }
 
 const ActivitiesSum = ({ activities }: Props) => {
   const trackedTime = activities.reduce(
-    (sum: number, activity: any) =>
-      activity.tracked ? sum + activity.tracked : sum,
+    (sum, activity) => (activity.tracked ? sum + activity.tracked : sum),
     0
   );
 

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,14 +1,17 @@
-import Link from "next/link";
+import Link from 'next/link';
 
 const Header = () => {
   return (
     <header>
       <nav className="border-gray-200 bg-white p-4 dark:bg-gray-800">
         <div className="container mx-auto flex flex-wrap items-center justify-between">
-          <Link href="/" className="flex items-center text-xl fond-semibold text-white">
+          <Link
+            href="/"
+            className="fond-semibold flex items-center text-xl text-white"
+          >
             UXMind Dashboard
           </Link>
-          <ul className="font-medium flex gap-8 items-center justify-center">
+          <ul className="flex items-center justify-center gap-8 font-medium">
             <li>
               <Link
                 href="/"

--- a/src/app/components/MembersList.tsx
+++ b/src/app/components/MembersList.tsx
@@ -1,7 +1,7 @@
 'use client';
-import { type User as HubstaffUser } from '@app-masters/hubstaff-node-client/dist/types';
 import { createColumnHelper } from '@tanstack/react-table';
 import Table from './ui/table';
+import { type HubstaffUser } from '../hubstaffValidators';
 
 interface Props {
   members: HubstaffUser[];
@@ -25,7 +25,7 @@ const MembersList = ({ members }: Props) => {
   return (
     <div className="mt-5">
       <div className="text-primary mb-2 mt-0 text-5xl font-medium leading-tight">
-        Members
+        Hubstaff Members
       </div>
       <Table data={members} columns={columns} />
     </div>

--- a/src/app/components/ProjectsList.tsx
+++ b/src/app/components/ProjectsList.tsx
@@ -1,7 +1,7 @@
 'use client';
-import { type Project as HubstaffProject } from '@app-masters/hubstaff-node-client/dist/types';
 import { createColumnHelper } from '@tanstack/react-table';
 import Table from './ui/table';
+import { type HubstaffProject } from '../hubstaffValidators';
 
 interface Props {
   projects: HubstaffProject[];
@@ -22,7 +22,7 @@ const ProjectsList = ({ projects }: Props) => {
   return (
     <div className="mt-8">
       <div className="text-primary mb-2 mt-0 text-5xl font-medium leading-tight">
-        Projects
+        Hubstaff Projects
       </div>
       <Table data={projects} columns={columns} />
     </div>

--- a/src/app/components/ui/table.tsx
+++ b/src/app/components/ui/table.tsx
@@ -24,7 +24,7 @@ function Table<T>({
   columns,
   onRowClick,
   onPageChange,
-  limit = 20,
+  limit = 10,
   paginationRange = 5, // How many page links to show in pagination, should be odd number
 }: Props<T>) {
   const table = useReactTable({

--- a/src/app/hubstaffClient.ts
+++ b/src/app/hubstaffClient.ts
@@ -1,48 +1,121 @@
 import { prisma } from '@/server/db';
-import Hubstaff from '@app-masters/hubstaff-node-client';
+import jwtDecode from 'jwt-decode';
+import { z } from 'zod';
+import _ from 'lodash';
 import { type HubstaffAccess } from '@prisma/client';
+import { URLSearchParams } from 'url';
 
-const ORGANIZATION_ID = process.env.ORGANIZATION_ID;
+const BASE_URL = 'https://api.hubstaff.com/v2';
 
-class HubstaffClient extends Hubstaff {
-  static async createClient() {
-    // We assume only one hubstaffAccess will ever exist in DB. Maybe in future we will have more?
-    const access = await prisma.hubstaffAccess.findFirstOrThrow().catch(() => {
-      console.log('HubstaffAccess does not exist in DB, creating new one');
-      return prisma.hubstaffAccess.create({
-        data: {
-          accessToken: process.env.ACCESS_TOKEN || '',
-          refreshToken: process.env.REFRESH_TOKEN || '',
+class HubstaffClient {
+  access: Partial<HubstaffAccess>;
+
+  constructor() {
+    this.access = {
+      refreshToken: process.env.REFRESH_TOKEN || '',
+    };
+  }
+
+  async refreshToken() {
+    if (!this.access.refreshToken) throw new Error('Refresh token is missing!');
+    const params = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: this.access.refreshToken,
+    });
+    const res = await fetch(
+      `https://account.hubstaff.com/access_tokens?${params.toString()}`,
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
         },
-      })
-    }
+      }
     );
 
-    return new HubstaffClient(access);
-  }
-  constructor(access: HubstaffAccess) {
-    super(access, async (accessToken: string, refreshToken: string) => {
-      console.log('Token has been refreshed', { accessToken });
-      return prisma.hubstaffAccess.update({
-        where: {},
-        data: {
-          accessToken,
-          refreshToken,
-        },
-      });
+    const access = z
+      .preprocess(
+        (value: unknown) => ({
+          accessToken: value.access_token,
+          refreshToken: value.refresh_token,
+        }),
+        z.object({
+          accessToken: z.string(),
+          refreshToken: z.string(),
+        })
+      )
+      .parse(await res.json());
+
+    const { exp } = z
+      .object({ exp: z.number() })
+      .parse(jwtDecode(access.accessToken));
+
+    this.access = await prisma.hubstaffAccess.update({
+      where: { id: this.access.id },
+      data: { ...access, exp },
     });
   }
-  async getOrganizationUsers() {
-    const members = await this.getOrganizationMembers(
-      ORGANIZATION_ID ? Number(ORGANIZATION_ID) : 0
-    );
-    const res = await Promise.all(
-      members.map(async (member) => {
-        const user = await this.getUser(member.user_id ? member.user_id : -1);
-        return user;
+
+  async maybeRefreshToken() {
+    // Get token from database if needed
+    if (!this.access.accessToken) {
+      // We assume only one hubstaffAccess will ever exist in DB. Maybe in future we will have more?
+      this.access = await prisma.hubstaffAccess.findFirstOrThrow().catch(() => {
+        console.log('HubstaffAccess does not exist in DB, creating new one');
+        return prisma.hubstaffAccess.create({
+          data: {
+            accessToken: process.env.ACCESS_TOKEN || '',
+            refreshToken: process.env.REFRESH_TOKEN || '',
+          },
+        });
+      });
+    }
+    if ((this.access.exp || 0) < Date.now() / 1000) {
+      await this.refreshToken();
+    }
+  }
+
+  async request(
+    endpoint: string,
+    options: Parameters<typeof fetch>[1] = {} // This type is needed to be able to pass custom cache & revalidate options
+  ) {
+    await this.maybeRefreshToken();
+    if (!this.access.accessToken)
+      throw new Error('accessToken missing - something is wrong');
+
+    const res = await fetch(`${BASE_URL}/${_.trimStart(endpoint, '/')}`, {
+      ...options,
+      ...(options.body && { ...{ body: JSON.stringify(options.body) } }),
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.access.accessToken || ''}`,
+      },
+    });
+    return res.json();
+  }
+
+  async get(endpoint: string, options: Parameters<typeof fetch>[1]) {
+    return this.request(endpoint, {
+      method: 'GET',
+      ...options,
+    });
+  }
+
+  async getProject(projectId: number) {
+    const res = await this.get(`projects/${projectId}`, {
+      next: { revalidate: 60 },
+    });
+    const { project } = z
+      .object({
+        project: z.object({
+          id: z.number(),
+          name: z.string(),
+          status: z.string(),
+        }),
       })
-    );
-    return res;
+      .parse(res);
+    return project;
   }
 }
 

--- a/src/app/hubstaffClient.ts
+++ b/src/app/hubstaffClient.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { prisma } from '@/server/db';
 import jwtDecode from 'jwt-decode';
 import { z } from 'zod';
@@ -37,16 +38,14 @@ class HubstaffClient {
     );
 
     const access = z
-      .preprocess(
-        (value: unknown) => ({
-          accessToken: value.access_token,
-          refreshToken: value.refresh_token,
-        }),
-        z.object({
-          accessToken: z.string(),
-          refreshToken: z.string(),
-        })
-      )
+      .object({
+        access_token: z.string(),
+        refresh_token: z.string(),
+      })
+      .transform((v) => ({
+        accessToken: v.access_token,
+        refreshToken: v.refresh_token,
+      }))
       .parse(await res.json());
 
     const { exp } = z

--- a/src/app/hubstaffClient.ts
+++ b/src/app/hubstaffClient.ts
@@ -6,8 +6,8 @@ import _ from 'lodash';
 import { type HubstaffAccess } from '@prisma/client';
 import { URLSearchParams } from 'url';
 import {
-  HubstaffActivity,
-  HubstaffProject,
+  type HubstaffActivity,
+  type HubstaffProject,
   activitySchema,
   paginationSchema,
   projectSchema,

--- a/src/app/hubstaffValidators.tsx
+++ b/src/app/hubstaffValidators.tsx
@@ -1,17 +1,20 @@
-import { z } from "zod";
+import { z } from 'zod';
+
+export const paginationSchema = z.object({
+  next_page_start_id: z.number().optional(),
+}).passthrough().optional();
 
 export const projectSchema = z.object({
   id: z.number(),
   name: z.string(),
   status: z.string(),
-});
+}).passthrough();
 export type HubstaffProject = z.infer<typeof projectSchema>;
-
 
 export const userSchema = z.object({
   id: z.number(),
   name: z.string(),
   email: z.string(),
   status: z.string(),
-})
+}).passthrough();
 export type HubstaffUser = z.infer<typeof userSchema>;

--- a/src/app/hubstaffValidators.tsx
+++ b/src/app/hubstaffValidators.tsx
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const projectSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  status: z.string(),
+});
+export type HubstaffProject = z.infer<typeof projectSchema>;
+
+
+export const userSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  email: z.string(),
+  status: z.string(),
+})
+export type HubstaffUser = z.infer<typeof userSchema>;

--- a/src/app/hubstaffValidators.tsx
+++ b/src/app/hubstaffValidators.tsx
@@ -1,20 +1,37 @@
 import { z } from 'zod';
 
-export const paginationSchema = z.object({
-  next_page_start_id: z.number().optional(),
-}).passthrough().optional();
+export const paginationSchema = z
+  .object({
+    next_page_start_id: z.number().optional(),
+  })
+  .passthrough()
+  .optional();
 
-export const projectSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  status: z.string(),
-}).passthrough();
+export const projectSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    status: z.string(),
+  })
+  .passthrough();
 export type HubstaffProject = z.infer<typeof projectSchema>;
 
-export const userSchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  email: z.string(),
-  status: z.string(),
-}).passthrough();
+export const userSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+    email: z.string(),
+    status: z.string(),
+  })
+  .passthrough();
 export type HubstaffUser = z.infer<typeof userSchema>;
+
+export const activitySchema = z
+  .object({
+    id: z.number(),
+    tracked: z.number(),
+    project_id: z.number(),
+    created_at: z.string().datetime(),
+  })
+  .passthrough();
+export type HubstaffActivity = z.infer<typeof activitySchema>;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,16 @@
-export default function Home() {
+import MembersList from './components/MembersList';
+import ProjectsList from './components/ProjectsList';
+import HubstaffClient from './hubstaffClient';
+
+export default async function Home() {
+  const client = new HubstaffClient();
+  const members = await client.getOrganizationMembers();
+  const projects = await client.getProjects();
+
   return (
     <main className="container mx-auto py-10">
-      Work in Progress
+      <MembersList members={members} />
+      <ProjectsList projects={projects} />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import ActivitiesList from './components/ActivitiesList';
+import ActivitiesSum from './components/ActivitiesSum';
 import MembersList from './components/MembersList';
 import ProjectsList from './components/ProjectsList';
 import HubstaffClient from './hubstaffClient';
@@ -14,6 +15,7 @@ export default async function Home() {
 
   return (
     <main className="container mx-auto py-10">
+      <ActivitiesSum activities={activities} />
       <MembersList members={members} />
       <ProjectsList projects={projects} />
       <ActivitiesList activities={activities} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import ActivitiesList from './components/ActivitiesList';
 import MembersList from './components/MembersList';
 import ProjectsList from './components/ProjectsList';
 import HubstaffClient from './hubstaffClient';
@@ -6,11 +7,16 @@ export default async function Home() {
   const client = new HubstaffClient();
   const members = await client.getOrganizationMembers();
   const projects = await client.getProjects();
+  const activities = await client.getActivities(
+    new Date('2023-07-01'),
+    new Date('2023-07-08')
+  );
 
   return (
     <main className="container mx-auto py-10">
       <MembersList members={members} />
       <ProjectsList projects={projects} />
+      <ActivitiesList activities={activities} />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,31 +1,7 @@
-import ProjectsList from './components/ProjectsList';
-import MembersList from './components/MembersList';
-import ActivitiesList from './components/ActivitiesList';
-import ActivitiesSum from './components/ActivitiesSum';
-import HubstaffClient from './hubstaffClient';
-
-export const revalidate = 3600;
-
-export default async function Home() {
-  const client = await HubstaffClient.createClient();
-  const projects = await client.getProjects(
-    process.env.ORGANIZATION_ID ? Number(process.env.ORGANIZATION_ID) : 0
-  );
-  const members = await client.getOrganizationUsers();
-  const activities = await client.getActivities(
-    process.env.ORGANIZATION_ID ? Number(process.env.ORGANIZATION_ID) : 0,
-    {
-      startTime: new Date(2023, 1, 1),
-      stopTime: new Date(2023, 1, 5),
-    }
-  );
-
+export default function Home() {
   return (
     <main className="container mx-auto py-10">
-      <ActivitiesSum activities={activities} />
-      <ProjectsList projects={projects} />
-      <MembersList members={members} />
-      <ActivitiesList activities={activities} />
+      Work in Progress
     </main>
   );
 }

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function SingleProject({ params }: Props) {
   const project = await getProject(params.id);
-  const client = await HubstaffClient.createClient();
+  const client = new HubstaffClient();
   const hubstaffProject = project.hubstaffId
     ? await client.getProject(Number(project.hubstaffId)).catch((e) => {
         console.log(e);

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -7,7 +7,6 @@ export const metadata = {
 
 export default async function Projects() {
   const projects = await prisma.project.findMany();
-  console.log(projects);
   return (
     <main className="container mx-auto py-10">
       <InnerProjectsList projects={projects} />


### PR DESCRIPTION
Use our own hubstaff client for API. The main reason is that we now use native `fetch` under the hood which allows for more fine-grained control over caching/revalidation: https://nextjs.org/docs/app/api-reference/functions/fetch

This is mostly a rewrite of original library: https://github.com/app-masters/hubstaff-node-client/blob/master/src/Hubstaff.ts

Advantages are: we now strictly validate hubstaff responses (with `zod`) and will have more control over pagination (original library load data in chunks of 500, and we might want to paginate data ourselves).